### PR TITLE
Add readonly replacement logic. Issue Fixed.

### DIFF
--- a/modules/contextExtensions.js
+++ b/modules/contextExtensions.js
@@ -129,8 +129,10 @@ class ContextExtensions {
 				if (typeof value === 'object') {
 					// Value is a reference, replace it with a definition
 					const description = newSchema[key].description;
+					const readonly = newSchema[key].readOnly;
 					newSchema[key] = newContext.getDefinition(value, swaggerSource, truncate, resolvedTypes, value.items ? level : level + 1);
 					if (typeof description === 'string') newSchema[key].description = description;
+					if(readonly) newSchema[key].readOnly = readonly;
 
 					// Set model name
 					if (value['$ref'] && typeof value['$ref'] === 'string') {


### PR DESCRIPTION
Add readonly property back when getting definition of reference so that the webpage will hide all readonly arguments correctly